### PR TITLE
Fix node version to 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "nodemon src/index.js",
     "start": "node src/index.js"
-  },
+  }, 
   "engines": {
-    "node": "12.x"
+    "node": "^10.x"
   },
   "dependencies": {
     "dotenv": "^8.0.0",


### PR DESCRIPTION
I think that put ^10.x allow use 10 and 12 node versions. For the project I think you don't have so much feature that doesn't run on version 10, and how 10 still LTS version I think that is OK use it.